### PR TITLE
Added cropRectColor and button font properties

### DIFF
--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
@@ -25,6 +25,8 @@
 @property (nonatomic, strong) NSString *confirmTitle;
 @property (nonatomic, strong) NSString *cancelTitle;
 @property (nonatomic, strong) UIColor *btnBgColor;
+@property (nonatomic, strong) UIFont *cancelBtnFont;
+@property (nonatomic, strong) UIFont *confirmBtnFont;
 
 /** Color of the crop rectangle (defaults to yellow if not specified) */
 @property (nonatomic, strong) UIColor *cropRectColor;

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
@@ -26,6 +26,9 @@
 @property (nonatomic, strong) NSString *cancelTitle;
 @property (nonatomic, strong) UIColor *btnBgColor;
 
+/** Color of the crop rectangle (defaults to yellow if not specified) */
+@property (nonatomic, strong) UIColor *cropRectColor;
+
 - (id)initWithImage:(UIImage *)originalImage cropFrame:(CGRect)cropFrame limitScaleRatio:(NSInteger)limitRatio;
 
 @end

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -104,7 +104,7 @@
     cancelBtn.backgroundColor = self.btnBgColor ? self.btnBgColor : [UIColor blackColor];
     cancelBtn.titleLabel.textColor = [UIColor whiteColor];
     [cancelBtn setTitle:self.cancelTitle ? self.cancelTitle : @"Cancel" forState:UIControlStateNormal];
-    [cancelBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
+    [cancelBtn.titleLabel setFont:self.cancelBtnFont ? self.cancelBtnFont : [UIFont boldSystemFontOfSize:18.0f]];
     [cancelBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
     [cancelBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];
     [cancelBtn.titleLabel setNumberOfLines:0];
@@ -116,7 +116,7 @@
     confirmBtn.backgroundColor = self.btnBgColor ? self.btnBgColor : [UIColor blackColor];
     confirmBtn.titleLabel.textColor = [UIColor whiteColor];
     [confirmBtn setTitle:self.confirmTitle ? self.confirmTitle : @"OK" forState:UIControlStateNormal];
-    [confirmBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
+    [confirmBtn.titleLabel setFont:self.confirmBtnFont ? self.confirmBtnFont : [UIFont boldSystemFontOfSize:18.0f]];
     [confirmBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
     confirmBtn.titleLabel.textColor = [UIColor whiteColor];
     [confirmBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -91,7 +91,7 @@
     [self.view addSubview:self.overlayView];
     
     self.ratioView = [[UIView alloc] initWithFrame:self.cropFrame];
-    self.ratioView.layer.borderColor = [UIColor yellowColor].CGColor;
+    self.ratioView.layer.borderColor = self.cropRectColor ? self.cropRectColor.CGColor : [UIColor yellowColor].CGColor;
     self.ratioView.layer.borderWidth = 1.0f;
     self.ratioView.autoresizingMask = UIViewAutoresizingNone;
     [self.view addSubview:self.ratioView];


### PR DESCRIPTION
Added cropRectColor property to be able to specify color of the crop rectangle (still defaults to yellow if not specified).  I need to be able to specify the color of the crop rectangle, and this change allows me to do so.

Also added `cancelBtnFont` and `confirmBtnFont` for further customization of buttons in VPImageCropperViewController.
